### PR TITLE
Introduce standalone Dockerfiles per product profile of WSO2 Stream Processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,4 @@
-# Compiled class file
 *.class
-
-# Log file
-*.log
-
-# BlueJ files
-*.ctxt
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
@@ -14,9 +7,17 @@
 *.jar
 *.war
 *.ear
-*.zip
-*.tar.gz
-*.rar
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# any packs that would be included
+*.exe
+*.tar.gz
+*.zip
+
+# IntelliJ IDEA
+.idea/
+*.iml
+
+rat.txt

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# docker-sp
+# WSO2 Stream Processor Docker Resources
+
+This repository contains following Docker resources:
+
+- Per-profile Dockerfiles
+
+Per-profile Dockerfiles enable us to build generic Docker images for deploying the product as profiles
+in containerized environments. Each includes the JDK and product distributions and a collection of utility libraries.

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -1,0 +1,70 @@
+# Dockerfiles for WSO2 Stream Processor #
+
+This section defines Dockerfiles and step-by-step instructions to build Docker images for product profiles provided by
+WSO2 Stream Processor 4.0.0, namely : <br>
+1. Dashboard
+2. Editor
+3. Manager
+4. Worker
+
+## How to build an image and run
+##### 1. Checkout this repository into your local machine using the following Git command.
+```
+git clone https://github.com/wso2/docker-sp.git
+```
+
+>The local copy of the `dockerfiles` directory will be referred to as `DOCKERFILE_HOME` from this point onwards.
+
+##### 2. Add JDK and WSO2 Stream Processor distributions to `<DOCKERFILE_HOME>/base/files`
+- Download [JDK 1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) 
+and copy that to `<DOCKERFILE_HOME>/base/files`.
+- Download [WSO2 Stream Processor 4.0.0 distribution](https://github.com/wso2/product-sp/releases) 
+and copy that to `<DOCKERFILE_HOME>/base/files`. <br>
+
+##### 3. Build the base Docker image.
+- For base, navigate to `<DOCKERFILE_HOME>/base` directory. <br>
+  Execute `docker build` command as shown below.
+    + `docker build -t wso2sp-base:4.0.0 .`
+        
+##### 4. Build Docker images specific to each profile.
+- For Dashboard, navigate to `<DOCKERFILE_HOME>/dashboard` directory. <br>
+  Execute `docker build` command as shown below. 
+    + `docker build -t wso2sp-dashboard:4.0.0 .`
+- For Editor, navigate to `<DOCKERFILE_HOME>/editor` directory. <br>
+  Execute `docker build` command as shown below. 
+    + `docker build -t wso2sp-editor:4.0.0 .`
+- For Manager, navigate to `<DOCKERFILE_HOME>/manager` directory. <br>
+  Execute `docker build` command as shown below. 
+    + `docker build -t wso2sp-manager:4.0.0 .`
+- For Worker, navigate to `<DOCKERFILE_HOME>/worker` directory. <br>
+  Execute `docker build` command as shown below. 
+    + `docker build -t wso2sp-worker:4.0.0 .`
+    
+##### 5. Running Docker images specific to each profile.
+- For Dashboard,
+    + `docker run -it -p 9643:9643 wso2sp-dashboard:4.0.0`
+- For Editor,
+    + `docker run -it -p 9390:9390 -p 9743:9743 wso2sp-editor:4.0.0`
+- For Manager,
+    + `docker run -it wso2sp-manager:4.0.0`
+- For Worker,
+    + `docker run -it wso2sp-worker:4.0.0`   
+
+##### 6. Accessing management console per each profile.
+- For Dashboard,
+    + Business Rules:<br>
+    `https://<DOCKER_HOST>:9643/business-rules`
+    + Portal:<br>
+    `https://<DOCKER_HOST>:9643/portal`
+    + Monitoring:<br>
+    `https://<DOCKER_HOST>:9643/monitoring`
+- For Editor,
+    + `http://<DOCKER_HOST>:9390/editor`
+    
+>In here, <DOCKER_HOST> refers to hostname or IP of the host machine on top of which containers are spawned.
+
+## Docker command usage references
+
+* [Docker build command reference](https://docs.docker.com/engine/reference/commandline/build/)
+* [Docker run command reference](https://docs.docker.com/engine/reference/run/)
+* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -1,0 +1,73 @@
+# ------------------------------------------------------------------------
+#
+# Copyright 2017 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# ------------------------------------------------------------------------
+
+# set to latest Ubuntu LTS
+FROM ubuntu:16.04
+MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
+
+# set user configurations
+ARG USER=wso2carbon
+ARG USER_GROUP=wso2
+ARG USER_HOME=/home/${USER}
+# set dependant files directory
+ARG FILES=./files
+# set jdk configurations
+ARG JDK_ARCHIVE=jdk-8u*-linux-x64.tar.gz
+ARG JAVA_HOME_PARENT=/opt
+ARG JAVA_HOME=${JAVA_HOME_PARENT}/java
+# set wso2 product configurations
+ARG WSO2_SERVER=wso2sp
+ARG WSO2_SERVER_VERSION=4.0.0
+ARG WSO2_SERVER_PACK=${WSO2_SERVER}-${WSO2_SERVER_VERSION}*.zip
+ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}-${WSO2_SERVER_VERSION}
+
+# install required packages
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --no-install-suggests \
+    net-tools \
+    curl \
+    iproute2 \
+    telnet \
+    unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+# create a user group and a user
+RUN groupadd --system ${USER_GROUP} && \
+    useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP} ${USER}
+
+# copy the jdk and wso2 product distribution zip files to user's home directory
+COPY ${FILES}/${JDK_ARCHIVE} ${JAVA_HOME_PARENT}/
+COPY ${FILES}/${WSO2_SERVER_PACK} ${USER_HOME}/
+
+# install the jdk, wso2 server, remove distributions and set folder permissions
+RUN mkdir -p ${JAVA_HOME} && \
+    tar -xf ${JAVA_HOME_PARENT}/${JDK_ARCHIVE} -C ${JAVA_HOME} --strip-components=1 && \
+    unzip -q ${USER_HOME}/${WSO2_SERVER_PACK} -d ${USER_HOME}/ && \
+    rm ${JAVA_HOME_PARENT}/${JDK_ARCHIVE} && \
+    rm ${USER_HOME}/${WSO2_SERVER_PACK} && \
+    chown -R ${USER}:${USER_GROUP} ${USER_HOME} && \
+    chmod -R g=u ${USER_HOME}
+
+# set the user and work directory
+USER ${USER}
+WORKDIR ${USER_HOME}
+
+# set environment variables
+ENV JAVA_HOME=${JAVA_HOME} \
+    PATH=$JAVA_HOME/bin:$PATH \
+    WSO2_SERVER_HOME=${WSO2_SERVER_HOME}

--- a/dockerfiles/dashboard/Dockerfile
+++ b/dockerfiles/dashboard/Dockerfile
@@ -1,0 +1,26 @@
+# ------------------------------------------------------------------------
+#
+# Copyright 2017 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# ------------------------------------------------------------------------
+
+# set to latest Ubuntu LTS
+FROM wso2sp-base:4.0.0
+MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
+
+# expose ports
+EXPOSE 9714 9643 9614 7713 7613
+
+ENTRYPOINT ${WSO2_SERVER_HOME}/bin/dashboard.sh

--- a/dockerfiles/editor/Dockerfile
+++ b/dockerfiles/editor/Dockerfile
@@ -1,0 +1,26 @@
+# ------------------------------------------------------------------------
+#
+# Copyright 2017 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# ------------------------------------------------------------------------
+
+# set to latest Ubuntu LTS
+FROM wso2sp-base:4.0.0
+MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
+
+# expose ports
+EXPOSE 9743 9715 9615 9390 7714 7614
+
+ENTRYPOINT ${WSO2_SERVER_HOME}/bin/editor.sh

--- a/dockerfiles/manager/Dockerfile
+++ b/dockerfiles/manager/Dockerfile
@@ -1,0 +1,26 @@
+# ------------------------------------------------------------------------
+#
+# Copyright 2017 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# ------------------------------------------------------------------------
+
+# set to latest Ubuntu LTS
+FROM wso2sp-base:4.0.0
+MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
+
+# expose ports
+EXPOSE 9543 9190
+
+ENTRYPOINT ${WSO2_SERVER_HOME}/bin/manager.sh

--- a/dockerfiles/worker/Dockerfile
+++ b/dockerfiles/worker/Dockerfile
@@ -1,0 +1,26 @@
+# ------------------------------------------------------------------------
+#
+# Copyright 2017 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# ------------------------------------------------------------------------
+
+# set to latest Ubuntu LTS
+FROM wso2sp-base:4.0.0
+MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
+
+# expose ports
+EXPOSE 9090 9443 9712 9612 7711 7611
+
+CMD ${WSO2_SERVER_HOME}/bin/worker.sh


### PR DESCRIPTION
## Purpose
> It is required to introduce standalone Dockerfiles for each product profile of WSO2 Stream Processor. This pull request introduces these Dockerfiles. A related issue is https://github.com/wso2/docker-sp/issues/1.

## Goals
> Introduce standalone Dockerfiles per product profile of WSO2 Stream Processor

## Documentation
> Please see README.md documentation.

## Test environment
> OS: Ubuntu version 16.04 LTS
> Docker version: 17.09.1-ce, build 19e2cf6