### PR TITLE
Improve to the Dockerfile to reduce image size and define user/group id. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ hs_err_pid*
 *.iml
 
 rat.txt
+dockerfiles/base/files/*
+

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -15,11 +15,11 @@ git clone https://github.com/wso2/docker-sp.git
 
 >The local copy of the `dockerfiles` directory will be referred to as `DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Add JDK and WSO2 Stream Processor distributions to `<DOCKERFILE_HOME>/base/files`
+##### 2. Copy the extracted JDK and WSO2 Stream Processor distributions to `<DOCKERFILE_HOME>/base/files`
 - Download [JDK 1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) 
-and copy that to `<DOCKERFILE_HOME>/base/files`.
+and extract it to `<DOCKERFILE_HOME>/base/files`.
 - Download [WSO2 Stream Processor 4.0.0 distribution](https://github.com/wso2/product-sp/releases) 
-and copy that to `<DOCKERFILE_HOME>/base/files`. <br>
+and extract it to `<DOCKERFILE_HOME>/base/files`. <br>
 
 ##### 3. Build the base Docker image.
 - For base, navigate to `<DOCKERFILE_HOME>/base` directory. <br>

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -22,18 +22,19 @@ MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations
 ARG USER=wso2carbon
+ARG USER_ID=802
 ARG USER_GROUP=wso2
+ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
 # set jdk configurations
-ARG JDK_ARCHIVE=jdk-8u*-linux-x64.tar.gz
-ARG JAVA_HOME_PARENT=/opt
-ARG JAVA_HOME=${JAVA_HOME_PARENT}/java
+ARG JDK=jdk1.8.0*
+ARG JAVA_HOME=${USER_HOME}/java
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2sp
 ARG WSO2_SERVER_VERSION=4.0.0
-ARG WSO2_SERVER_PACK=${WSO2_SERVER}-${WSO2_SERVER_VERSION}*.zip
+ARG WSO2_SERVER_PACK=${WSO2_SERVER}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}-${WSO2_SERVER_VERSION}
 
 # install required packages
@@ -47,21 +48,12 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # create a user group and a user
-RUN groupadd --system ${USER_GROUP} && \
-    useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP} ${USER}
+RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
+    useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
 
 # copy the jdk and wso2 product distribution zip files to user's home directory
-COPY ${FILES}/${JDK_ARCHIVE} ${JAVA_HOME_PARENT}/
-COPY ${FILES}/${WSO2_SERVER_PACK} ${USER_HOME}/
-
-# install the jdk, wso2 server, remove distributions and set folder permissions
-RUN mkdir -p ${JAVA_HOME} && \
-    tar -xf ${JAVA_HOME_PARENT}/${JDK_ARCHIVE} -C ${JAVA_HOME} --strip-components=1 && \
-    unzip -q ${USER_HOME}/${WSO2_SERVER_PACK} -d ${USER_HOME}/ && \
-    rm ${JAVA_HOME_PARENT}/${JDK_ARCHIVE} && \
-    rm ${USER_HOME}/${WSO2_SERVER_PACK} && \
-    chown -R ${USER}:${USER_GROUP} ${USER_HOME} && \
-    chmod -R g=u ${USER_HOME}
+COPY --chown=wso2carbon:wso2 ${FILES}/${JDK} ${USER_HOME}/java
+COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${USER_HOME}/${WSO2_SERVER_PACK}/
 
 # set the user and work directory
 USER ${USER}


### PR DESCRIPTION
## Purpose
- Reduce the size of the built docker image. 
- Define user id and group id of docker user.

This fix #3 and  fix #4.

## Approach
- Copy the extracted JDK and WSO2 SP distribution instead of copying the tar.gz/zip archives and extracting it during the `docker buil`. This eliminates the intermediate layers that contained the archives which helps reduce the resulting image size.
- Define the user id and group id of the Docker user since it is needed to manage permissions of volume mounts.  
