### PR TITLE
Pack required client libraries to the docker image

### DIFF
--- a/docker-compose/manager-worker-dashboard/README.md
+++ b/docker-compose/manager-worker-dashboard/README.md
@@ -8,9 +8,11 @@ Runs a pre configured Stream Processor setup with Kafka broker and Stream Proces
 
 ## How to deploy
 
-  1. Pull the Kafka, Stream Processor manager, worker and dashboard images or build them:
+  1. Build the Kafka, Stream Processor manager, worker and dashboard images using [SP Dockerfiles](../../dockerfiles/README.md)
 
-     - [Stream Processor](../../dockerfiles/README.md)
+     > In the `docker-compose.yml`, remove the `dockerhub.wso2.com/` prefix from the `image` name
+
+     > For example, change the line `image: dockerhub.wso2.com/kafka:2.11-0.10.0.0` to `image: kafka:2.11-0.10.0.0`
 
   2. Pull MySQL Docker image:
      ```
@@ -26,36 +28,12 @@ Runs a pre configured Stream Processor setup with Kafka broker and Stream Proces
      cd [docker-sp]/docker-compose/manager-worker-dashboard
      ```
 
-  5. Download [MySQL Connector/J](https://dev.mysql.com/downloads/connector/j/) v5.1.45 and copy its JAR file to the following path:
-     ```
-     cp path/to/mysql-connector-java-5.1.35/mysql-connector-java-5.1.45-bin.jar [docker-sp]/docker-compose/manager-worker-dashboard/lib/
-     ```
-
-  6. Convert and copy the Kafka client jars from the `kafka_2.11-0.10.0.0/libs/` to `docker-compose/manager-worker-dashboard/lib` directory
-
-     The list of required client jars are;
-     - kafka_2.11-0.10.2.1.jar
-     - kafka-clients-0.10.2.1.jar
-     - metrics-core-2.2.0.jar
-     - scala-library-2.11.8.jar
-     - scala-parser-combinators_2.11-1.0.4.jar
-     - zkclient-0.10.jar
-     - zookeeper-3.4.9.jar
-
-     <br/>
-
-     > Use the `jartobundle.sh` script found it `wso2sp-4.0.0/bin` as shown below; note that you will have to run this command for each jar mentioned above
-
-     ```
-     ./wso2sp-4.0.0/bin/jartobundle.sh path/to/kafka/client/jar [docker-sp]/docker-compose/manager-worker-dashboard/lib
-     ```
-
-  7. Execute the following Docker Compose command to start the deployment:
+  5. Execute the following Docker Compose command to start the deployment:
      ```
      docker-compose up
      ```
 
-  8. In order to publish events from the Docker host machine, configure the Kafka container's id in the /etc/hosts file. This can be done as follows;
+  6. In order to publish events from the Docker host machine, configure the Kafka container's id in the /etc/hosts file. This can be done as follows;
      - Get the `container_id` of the Kafka container using `docker ps` command, name of the Kafka container is `wso2sp-kafka`
      - Use the `container_id` obtained above to find the IP address of the container using, `docker inspect <container_id>` command
      - Add a host entry for the `container_id` with the IP address obtained above
@@ -66,12 +44,12 @@ Runs a pre configured Stream Processor setup with Kafka broker and Stream Proces
      <container_ip> <container_id>
      ```
 
-  9. In the Siddhi apps, set the hostname of the `bootstrap.server` as `kafka` as shown below;
+  7. In the Siddhi apps, set the hostname of the `bootstrap.server` as `kafka` as shown below;
      ```
      bootstrap.servers='kafka:9092',
      ```
 
-  10. Add the following host entry for Stream Processor dashboard component;
+  8. Add the following host entry for Stream Processor dashboard component;
       ```
       127.0.0.1 wso2sp-dashboard
       ```

--- a/docker-compose/manager-worker-dashboard/docker-compose.yml
+++ b/docker-compose/manager-worker-dashboard/docker-compose.yml
@@ -40,13 +40,6 @@ services:
         condition: service_healthy
     volumes:
       - ./manager/conf/deployment.yaml:/home/wso2carbon/wso2sp-4.0.0/conf/manager/deployment.yaml
-      - ./lib/kafka_2.11_0.10.0.0_1.0.0.jar:/home/wso2carbon/wso2sp-4.0.0/lib/kafka_2.11_0.10.0.0_1.0.0.jar
-      - ./lib/kafka_clients_0.10.0.0_1.0.0.jar:/home/wso2carbon/wso2sp-4.0.0/lib/kafka_clients_0.10.0.0_1.0.0.jar
-      - ./lib/metrics_core_2.2.0_1.0.0.jar:/home/wso2carbon/wso2sp-4.0.0/lib/metrics_core_2.2.0_1.0.0.jar
-      - ./lib/scala_library_2.11.8_1.0.0.jar:/home/wso2carbon/wso2sp-4.0.0/lib/scala_library_2.11.8_1.0.0.jar
-      - ./lib/scala_parser_combinators_2.11_1.0.4_1.0.0.jar:/home/wso2carbon/wso2sp-4.0.0/lib/scala_parser_combinators_2.11_1.0.4_1.0.0.jar
-      - ./lib/zkclient_0.8_1.0.0.jar:/home/wso2carbon/wso2sp-4.0.0/lib/zkclient_0.8_1.0.0.jar
-      - ./lib/zookeeper_3.4.6_1.0.0.jar:/home/wso2carbon/wso2sp-4.0.0/lib/zookeeper_3.4.6_1.0.0.jar
     links:
       - kafka
   worker:
@@ -64,14 +57,6 @@ services:
         condition: service_healthy
     volumes:
       - ./worker/conf/deployment.yaml:/home/wso2carbon/wso2sp-4.0.0/conf/worker/deployment.yaml
-      - ./lib/kafka_2.11_0.10.0.0_1.0.0.jar:/home/wso2carbon/wso2sp-4.0.0/lib/kafka_2.11_0.10.0.0_1.0.0.jar
-      - ./lib/kafka_clients_0.10.0.0_1.0.0.jar:/home/wso2carbon/wso2sp-4.0.0/lib/kafka_clients_0.10.0.0_1.0.0.jar
-      - ./lib/metrics_core_2.2.0_1.0.0.jar:/home/wso2carbon/wso2sp-4.0.0/lib/metrics_core_2.2.0_1.0.0.jar
-      - ./lib/scala_library_2.11.8_1.0.0.jar:/home/wso2carbon/wso2sp-4.0.0/lib/scala_library_2.11.8_1.0.0.jar
-      - ./lib/scala_parser_combinators_2.11_1.0.4_1.0.0.jar:/home/wso2carbon/wso2sp-4.0.0/lib/scala_parser_combinators_2.11_1.0.4_1.0.0.jar
-      - ./lib/zkclient_0.8_1.0.0.jar:/home/wso2carbon/wso2sp-4.0.0/lib/zkclient_0.8_1.0.0.jar
-      - ./lib/zookeeper_3.4.6_1.0.0.jar:/home/wso2carbon/wso2sp-4.0.0/lib/zookeeper_3.4.6_1.0.0.jar
-      - ./lib/mysql-connector-java-5.1.45-bin.jar:/home/wso2carbon/wso2sp-4.0.0/lib/mysql-connector-java-5.1.45-bin.jar
     links:
       - manager
   dashboard:
@@ -89,4 +74,3 @@ services:
         condition: service_healthy
     volumes:
       - ./dashboard/conf/deployment.yaml:/home/wso2carbon/wso2sp-4.0.0/conf/dashboard/deployment.yaml
-      - ./lib/mysql-connector-java-5.1.45-bin.jar:/home/wso2carbon/wso2sp-4.0.0/lib/mysql-connector-java-5.1.45-bin.jar

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -23,12 +23,36 @@ and extract it to `<DOCKERFILE_HOME>/base/files`.
 - Download [WSO2 Stream Processor 4.0.0 distribution](https://github.com/wso2/product-sp/releases) 
 and extract it to `<DOCKERFILE_HOME>/base/files`. <br>
 
-##### 3. Build the base Docker image.
+##### 3. Download [MySQL Connector/J](https://dev.mysql.com/downloads/connector/j/) v5.1.45 and copy the jar to `<DOCKERFILE_HOME>/base/files`
+   ```
+   cp path/to/mysql/connector/jar <DOCKERFILE_HOME>/base/files
+   ```
+
+##### 4. Convert and copy the Kafka client jars from the `kafka_2.11-0.10.0.0/libs/` to `<DOCKERFILE_HOME>/base/files` directory
+
+The list of required client jars are;
+
+- kafka_2.11-0.10.2.1.jar
+- kafka-clients-0.10.2.1.jar
+- metrics-core-2.2.0.jar
+- scala-library-2.11.8.jar
+- scala-parser-combinators_2.11-1.0.4.jar
+- zkclient-0.10.jar
+- zookeeper-3.4.9.jar
+
+> Use the `jartobundle.sh` script found it `wso2sp-4.0.0/bin` as shown below; note that you will have to run this command for each jar mentioned above
+
+  ```
+  ./wso2sp-4.0.0/bin/jartobundle.sh path/to/kafka/client/jar <DOCKERFILE_HOME>/base/files
+  ```
+
+
+##### 4. Build the base Docker image.
 - For base, navigate to `<DOCKERFILE_HOME>/base` directory. <br>
   Execute `docker build` command as shown below.
     + `docker build -t wso2sp-base:4.0.0 .`
         
-##### 4. Build Docker images specific to each profile.
+##### 5. Build Docker images specific to each profile.
 - For Dashboard, navigate to `<DOCKERFILE_HOME>/dashboard` directory. <br>
   Execute `docker build` command as shown below. 
     + `docker build -t wso2sp-dashboard:4.0.0 .`
@@ -42,7 +66,7 @@ and extract it to `<DOCKERFILE_HOME>/base/files`. <br>
   Execute `docker build` command as shown below. 
     + `docker build -t wso2sp-worker:4.0.0 .`
     
-##### 5. Running Docker images specific to each profile.
+##### 6. Running Docker images specific to each profile.
 - For Dashboard,
     + `docker run -it -p 9643:9643 wso2sp-dashboard:4.0.0`
 - For Editor,
@@ -52,7 +76,7 @@ and extract it to `<DOCKERFILE_HOME>/base/files`. <br>
 - For Worker,
     + `docker run -it wso2sp-worker:4.0.0`   
 
-##### 6. Accessing management console per each profile.
+##### 7. Accessing management console per each profile.
 - For Dashboard,
     + Business Rules:<br>
     `https://<DOCKER_HOST>:9643/business-rules`

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -40,12 +40,7 @@ ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}-${WSO2_SERVER_VERSION}
 # install required packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --no-install-suggests \
-    net-tools \
-    curl \
-    iproute2 \
-    telnet \
-    netcat \
-    unzip && \
+    netcat && \
     rm -rf /var/lib/apt/lists/*
 
 # create a user group and a user
@@ -55,6 +50,16 @@ RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
 # copy the jdk and wso2 product distribution zip files to user's home directory
 COPY --chown=wso2carbon:wso2 ${FILES}/${JDK} ${USER_HOME}/java
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${USER_HOME}/${WSO2_SERVER_PACK}/
+
+# copy the kafka client libraries
+COPY --chown=wso2carbon:wso2 ${FILES}/kafka_2.11_0.10.0.0_1.0.0.jar ${USER_HOME}/${WSO2_SERVER_PACK}/lib/
+COPY --chown=wso2carbon:wso2 ${FILES}/kafka_clients_0.10.0.0_1.0.0.jar ${USER_HOME}/${WSO2_SERVER_PACK}/lib/
+COPY --chown=wso2carbon:wso2 ${FILES}/metrics_core_2.2.0_1.0.0.jar ${USER_HOME}/${WSO2_SERVER_PACK}/lib/
+COPY --chown=wso2carbon:wso2 ${FILES}/scala_library_2.11.8_1.0.0.jar ${USER_HOME}/${WSO2_SERVER_PACK}/lib/
+COPY --chown=wso2carbon:wso2 ${FILES}/scala_parser_combinators_2.11_1.0.4_1.0.0.jar ${USER_HOME}/${WSO2_SERVER_PACK}/lib/
+COPY --chown=wso2carbon:wso2 ${FILES}/zkclient_0.8_1.0.0.jar ${USER_HOME}/${WSO2_SERVER_PACK}/lib/
+COPY --chown=wso2carbon:wso2 ${FILES}/zookeeper_3.4.6_1.0.0.jar ${USER_HOME}/${WSO2_SERVER_PACK}/lib/
+COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-5.1.45-bin.jar ${USER_HOME}/${WSO2_SERVER_PACK}/lib/
 
 # set the user and work directory
 USER ${USER}


### PR DESCRIPTION
## Purpose
Pack the Kafka client libraries and the JDBC driver to the docker image while building the image itself. This way, the client libraries doesn't need to be mounted when running the docker-compose.