### PR TITLE
Update container init scripts to pass all the parameters to the WSO2 SP init scripts

### DIFF
--- a/dockerfiles/dashboard/init.sh
+++ b/dockerfiles/dashboard/init.sh
@@ -37,4 +37,4 @@ test -d ${volumes} && cp -r ${volumes}/* ${WSO2_SERVER_HOME}/
 
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/dashboard.sh
+sh ${WSO2_SERVER_HOME}/bin/dashboard.sh $*

--- a/dockerfiles/editor/init.sh
+++ b/dockerfiles/editor/init.sh
@@ -37,4 +37,4 @@ test -d ${volumes} && cp -r ${volumes}/* ${WSO2_SERVER_HOME}/
 
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/editor.sh
+sh ${WSO2_SERVER_HOME}/bin/editor.sh $*

--- a/dockerfiles/manager/init.sh
+++ b/dockerfiles/manager/init.sh
@@ -45,4 +45,4 @@ if test -d ${k8s_volumes}/${WSO2_SERVER_PROFILE}/conf; then
 fi
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/manager.sh
+sh ${WSO2_SERVER_HOME}/bin/manager.sh $*

--- a/dockerfiles/worker/init.sh
+++ b/dockerfiles/worker/init.sh
@@ -45,4 +45,4 @@ if test -d ${k8s_volumes}/${WSO2_SERVER_PROFILE}/conf; then
 fi
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/worker.sh
+sh ${WSO2_SERVER_HOME}/bin/worker.sh $*


### PR DESCRIPTION
## Purpose
> Currently the Docker entry scripts (init.sh) do not pass the input parameters into the WSO2 Stream Processor init scripts. This hinders the ability to provide parameters like specifying the Siddhi App to run in the Siddhi Worker which is quite important.

## Goals
> Update the docker entry scripts (init.sh) to pass all the input arguments into the WSO2 Stream Processor init scripts

## Test environment
> Docker 18.03.1-ce