### PR TITLE
Add directory in home to deploy Siddhi files

### DIFF
--- a/dockerfiles/alpine/editor/init.sh
+++ b/dockerfiles/alpine/editor/init.sh
@@ -20,6 +20,7 @@ set -e
 # volume mounts
 config_volume=${WORKING_DIRECTORY}/wso2-config-volume
 artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
+siddhi_files_volume=${WORKING_DIRECTORY}/siddhi-files
 
 # a grace period for mounts to be setup
 echo "Waiting for all volumes to be mounted..."
@@ -67,6 +68,8 @@ test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" 
 test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+# copy siddhi files mounted to siddhi_files_volume
+test -d ${siddhi_files_volume}/ && cp -r ${siddhi_files_volume}/* ${WSO2_SERVER_HOME}/wso2/editor/deployment/workspace/
 
 # start the WSO2 Carbon server profile
 sh ${WSO2_SERVER_HOME}/bin/editor.sh $*

--- a/dockerfiles/alpine/worker/init.sh
+++ b/dockerfiles/alpine/worker/init.sh
@@ -20,6 +20,7 @@ set -e
 # volume mounts
 config_volume=${WORKING_DIRECTORY}/wso2-config-volume
 artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
+siddhi_files_volume=${WORKING_DIRECTORY}/siddhi-files
 
 # a grace period for mounts to be setup
 echo "Waiting for all volumes to be mounted..."
@@ -67,6 +68,8 @@ test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" 
 test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+# copy siddhi files mounted to siddhi_files_volume
+test -d ${siddhi_files_volume}/ && cp -r ${siddhi_files_volume}/* ${WSO2_SERVER_HOME}/wso2/worker/deployment/siddhi-files/
 
 # start the WSO2 Carbon server profile
 sh ${WSO2_SERVER_HOME}/bin/worker.sh $*

--- a/dockerfiles/centos/editor/init.sh
+++ b/dockerfiles/centos/editor/init.sh
@@ -20,6 +20,7 @@ set -e
 # volume mounts
 config_volume=${WORKING_DIRECTORY}/wso2-config-volume
 artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
+siddhi_files_volume=${WORKING_DIRECTORY}/siddhi-files
 
 # a grace period for mounts to be setup
 echo "Waiting for all volumes to be mounted..."
@@ -67,6 +68,8 @@ test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" 
 test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+# copy siddhi files mounted to siddhi_files_volume
+test -d ${siddhi_files_volume}/ && cp -r ${siddhi_files_volume}/* ${WSO2_SERVER_HOME}/wso2/editor/deployment/workspace/
 
 # start the WSO2 Carbon server profile
 sh ${WSO2_SERVER_HOME}/bin/editor.sh $*

--- a/dockerfiles/centos/worker/init.sh
+++ b/dockerfiles/centos/worker/init.sh
@@ -20,6 +20,7 @@ set -e
 # volume mounts
 config_volume=${WORKING_DIRECTORY}/wso2-config-volume
 artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
+siddhi_files_volume=${WORKING_DIRECTORY}/siddhi-files
 
 # a grace period for mounts to be setup
 echo "Waiting for all volumes to be mounted..."
@@ -67,6 +68,8 @@ test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" 
 test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+# copy siddhi files mounted to siddhi_files_volume
+test -d ${siddhi_files_volume}/ && cp -r ${siddhi_files_volume}/* ${WSO2_SERVER_HOME}/wso2/worker/deployment/siddhi-files/
 
 # start the WSO2 Carbon server profile
 sh ${WSO2_SERVER_HOME}/bin/worker.sh $*

--- a/dockerfiles/ubuntu/editor/init.sh
+++ b/dockerfiles/ubuntu/editor/init.sh
@@ -20,6 +20,7 @@ set -e
 # volume mounts
 config_volume=${WORKING_DIRECTORY}/wso2-config-volume
 artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
+siddhi_files_volume=${WORKING_DIRECTORY}/siddhi-files
 
 # capture Docker container IP from the container's /etc/hosts file
 docker_container_ip=$(awk 'END{print $1}' /etc/hosts)
@@ -34,6 +35,8 @@ test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" 
 test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+# copy siddhi files mounted to siddhi_files_volume
+test -d ${siddhi_files_volume}/ && cp -r ${siddhi_files_volume}/* ${WSO2_SERVER_HOME}/wso2/editor/deployment/workspace/
 
 # start the WSO2 Carbon server profile
 sh ${WSO2_SERVER_HOME}/bin/editor.sh $*

--- a/dockerfiles/ubuntu/worker/init.sh
+++ b/dockerfiles/ubuntu/worker/init.sh
@@ -20,6 +20,7 @@ set -e
 # volume mounts
 config_volume=${WORKING_DIRECTORY}/wso2-config-volume
 artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
+siddhi_files_volume=${WORKING_DIRECTORY}/siddhi-files
 
 # capture Docker container IP from the container's /etc/hosts file
 docker_container_ip=$(awk 'END{print $1}' /etc/hosts)
@@ -34,6 +35,8 @@ test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" 
 test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 # copy any artifact changes mounted to artifact_volume
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+# copy siddhi files mounted to siddhi_files_volume
+test -d ${siddhi_files_volume}/ && cp -r ${siddhi_files_volume}/* ${WSO2_SERVER_HOME}/wso2/worker/deployment/siddhi-files/
 
 # start the WSO2 Carbon server profile
 sh ${WSO2_SERVER_HOME}/bin/worker.sh $*


### PR DESCRIPTION
## Purpose
This PR copies Siddhi files hosted in `/home/wso2carbon/siddhi-files` directory into the respective location within the WSO2 SP distribution as follows.
- **Editor:** `/home/wso2carbon/wso2sp-{{version}}/wso2/editor/deployment/workspace`
- **Worker:** `/home/wso2carbon/wso2sp-{{version}}/wso2/worker/deployment/siddhi-files`

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes