### PR TITLE
Use AdoptOpenJDK 8 in WSO2 Stream Processor and related product Docker resources

### DIFF
--- a/dockerfiles/alpine/README.md
+++ b/dockerfiles/alpine/README.md
@@ -22,7 +22,7 @@ git clone https://github.com/wso2/docker-sp.git
 
 >The local copy of the `dockerfiles/alpine` directory will be referred to as `DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Copy the extract JDK and WSO2 Stream Processor distributions to `<DOCKERFILE_HOME>/base/files`.
+##### 2. Copy the extract WSO2 Stream Processor distribution to `<DOCKERFILE_HOME>/base/files`.
 
 - Download [WSO2 Stream Processor 4.3.0 distribution](https://github.com/wso2/product-sp/releases) 
 and extract it to `<DOCKERFILE_HOME>/base/files`. <br>

--- a/dockerfiles/alpine/README.md
+++ b/dockerfiles/alpine/README.md
@@ -26,11 +26,11 @@ git clone https://github.com/wso2/docker-sp.git
 
 - Download [WSO2 Stream Processor 4.3.0 distribution](https://github.com/wso2/product-sp/releases) 
 and extract it to `<DOCKERFILE_HOME>/base/files`. <br>
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) and copy that to `<DOCKERFILE_HOME>/base/files` folder.<br>
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j) and copy that to `<DOCKERFILE_HOME>/base/files` folder.<br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
+  <DOCKERFILE_HOME>/base/files/mysql-connector-java-<version>-bin.jar
   <DOCKERFILE_HOME>/base/files/wso2sp-4.3.0/
   ```
   

--- a/dockerfiles/alpine/base/Dockerfile
+++ b/dockerfiles/alpine/base/Dockerfile
@@ -18,7 +18,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:alpine
+FROM adoptopenjdk/openjdk8:jdk8u192-b12-alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
 
 # set user configurations

--- a/dockerfiles/alpine/base/Dockerfile
+++ b/dockerfiles/alpine/base/Dockerfile
@@ -17,8 +17,8 @@
 #
 # ------------------------------------------------------------------------
 
-# set to latest Alpine
-FROM openjdk:8u171-jdk-alpine3.8
+# set base Docker image to AdoptOpenJDK Alpine Docker image
+FROM adoptopenjdk/openjdk8:alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
 
 # set user configurations
@@ -53,10 +53,9 @@ The Docker container contains the WSO2 product with its latest updates,\n\
 which are under the End User License Agreement (EULA) 2.0.\n\
 Read more about EULA 2.0 (https://wso2.com/licenses/wso2-update/2.0).\n"' > "$ENV"
 
-# copy the jdk and wso2 product distribution zip files to user's home directory
+# copy the wso2 product distribution to user's home directory
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
-
-# copy the jdk and wso2 product distribution zip files to user's home directory
+# copy the Kafka client jars to the product home
 COPY --chown=wso2carbon:wso2 ${FILES}/kafka_2.11_0.10.0.0_1.0.0.jar ${USER_HOME}/${WSO2_SERVER_PACK}/lib/
 COPY --chown=wso2carbon:wso2 ${FILES}/kafka_clients_0.10.0.0_1.0.0.jar ${USER_HOME}/${WSO2_SERVER_PACK}/lib/
 COPY --chown=wso2carbon:wso2 ${FILES}/metrics_core_2.2.0_1.0.0.jar ${USER_HOME}/${WSO2_SERVER_PACK}/lib/
@@ -66,21 +65,10 @@ COPY --chown=wso2carbon:wso2 ${FILES}/zkclient_0.8_1.0.0.jar ${USER_HOME}/${WSO2
 COPY --chown=wso2carbon:wso2 ${FILES}/zookeeper_3.4.6_1.0.0.jar ${USER_HOME}/${WSO2_SERVER_PACK}/lib/
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-5.1.45-bin.jar ${USER_HOME}/${WSO2_SERVER_PACK}/lib/
 
-# create Java prefs dir
-# this is to avoid warning logs printed by FileSystemPreferences class
-RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
-    mkdir -p ${USER_HOME}/.java/.userPrefs  && \
-    chmod -R 755 ${USER_HOME}/.java && \
-    chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
-
 # set environment variables
 ENV WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
-    JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs"
+    WORKING_DIRECTORY=${USER_HOME}
 
 # set the user and work directory
 USER ${USER_ID}
 WORKDIR ${USER_HOME}
-
-# set environment variables
-ENV WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
-    WORKING_DIRECTORY=${USER_HOME}

--- a/dockerfiles/alpine/base/Dockerfile
+++ b/dockerfiles/alpine/base/Dockerfile
@@ -37,9 +37,7 @@ ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER_PACK}
 ENV ENV=${USER_HOME}"/.ashrc"
 
 # install required packages
-RUN  apk add --update --no-cache \
-     curl \
-     netcat-openbsd && \
+RUN  apk add --update --no-cache netcat-openbsd && \
      rm -rf /var/cache/apk/*
 
 # create a user group and a user

--- a/dockerfiles/alpine/dashboard/init.sh
+++ b/dockerfiles/alpine/dashboard/init.sh
@@ -69,4 +69,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/dashboard.sh $*
+sh ${WSO2_SERVER_HOME}/bin/dashboard.sh "$@"

--- a/dockerfiles/alpine/editor/init.sh
+++ b/dockerfiles/alpine/editor/init.sh
@@ -69,4 +69,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/editor.sh $*
+sh ${WSO2_SERVER_HOME}/bin/editor.sh "$@"

--- a/dockerfiles/alpine/manager/init.sh
+++ b/dockerfiles/alpine/manager/init.sh
@@ -69,4 +69,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/manager.sh $*
+sh ${WSO2_SERVER_HOME}/bin/manager.sh "$@"

--- a/dockerfiles/alpine/worker/init.sh
+++ b/dockerfiles/alpine/worker/init.sh
@@ -69,4 +69,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/worker.sh $*
+sh ${WSO2_SERVER_HOME}/bin/worker.sh "$@"

--- a/dockerfiles/centos/README.md
+++ b/dockerfiles/centos/README.md
@@ -27,12 +27,12 @@ git clone https://github.com/wso2/docker-sp.git
 - Download [AdoptOpenJDK 8](https://adoptopenjdk.net/) and extract it to `<DOCKERFILE_HOME>/base/files`.
 - Download [WSO2 Stream Processor 4.3.0 distribution](https://github.com/wso2/product-sp/releases) 
 and extract it to `<DOCKERFILE_HOME>/base/files`. <br>
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) and copy that to `<DOCKERFILE_HOME>/base/files` folder.<br>
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j) and copy that to `<DOCKERFILE_HOME>/base/files` folder.<br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
   <DOCKERFILE_HOME>/base/files/jdk8u<version>/
-  <DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
+  <DOCKERFILE_HOME>/base/files/mysql-connector-java-<version>-bin.jar
   <DOCKERFILE_HOME>/base/files/wso2sp-4.3.0/
   ```
 

--- a/dockerfiles/centos/README.md
+++ b/dockerfiles/centos/README.md
@@ -22,21 +22,20 @@ git clone https://github.com/wso2/docker-sp.git
 
 >The local copy of the `dockerfiles/centos` directory will be referred to as `DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Copy the extract JDK and WSO2 Stream Processor distributions to `<DOCKERFILE_HOME>/base/files`.
+##### 2. Copy and extract JDK and WSO2 Stream Processor distributions to `<DOCKERFILE_HOME>/base/files`.
 
-- Download [JDK v1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) 
-and extract it to `<DOCKERFILE_HOME>/base/files`.
+- Download [AdoptOpenJDK 8](https://adoptopenjdk.net/) and extract it to `<DOCKERFILE_HOME>/base/files`.
 - Download [WSO2 Stream Processor 4.3.0 distribution](https://github.com/wso2/product-sp/releases) 
 and extract it to `<DOCKERFILE_HOME>/base/files`. <br>
 - Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) and copy that to `<DOCKERFILE_HOME>/base/files` folder.<br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <DOCKERFILE_HOME>/base/files/jdk<version>/
+  <DOCKERFILE_HOME>/base/files/jdk8u<version>/
   <DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
   <DOCKERFILE_HOME>/base/files/wso2sp-4.3.0/
   ```
-  
+
 >Please refer to [WSO2 Update Manager documentation](https://docs.wso2.com/display/WUM300/WSO2+Update+Manager)
 in order to obtain latest bug fixes and updates for the product.
 

--- a/dockerfiles/centos/base/Dockerfile
+++ b/dockerfiles/centos/base/Dockerfile
@@ -29,7 +29,7 @@ ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
 # set jdk configurations
-ARG JDK=jdk1.8.0*
+ARG JDK=jdk8u*
 ARG JAVA_HOME=${USER_HOME}/java
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2sp
@@ -55,8 +55,7 @@ RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
 # copy the jdk and wso2 product distributions to user's home directory
 COPY --chown=wso2carbon:wso2 ${FILES}/${JDK} ${USER_HOME}/java/
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
-
-# copy the jdk and wso2 product distribution zip files to user's home directory
+# copy the Kafka client jars to the product home
 COPY --chown=wso2carbon:wso2 ${FILES}/kafka_2.11_0.10.0.0_1.0.0.jar ${WSO2_SERVER_HOME}/lib/
 COPY --chown=wso2carbon:wso2 ${FILES}/kafka_clients_0.10.0.0_1.0.0.jar ${WSO2_SERVER_HOME}/lib/
 COPY --chown=wso2carbon:wso2 ${FILES}/metrics_core_2.2.0_1.0.0.jar ${WSO2_SERVER_HOME}/lib/

--- a/dockerfiles/centos/dashboard/init.sh
+++ b/dockerfiles/centos/dashboard/init.sh
@@ -69,4 +69,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/dashboard.sh $*
+sh ${WSO2_SERVER_HOME}/bin/dashboard.sh "$@"

--- a/dockerfiles/centos/editor/init.sh
+++ b/dockerfiles/centos/editor/init.sh
@@ -69,4 +69,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/editor.sh $*
+sh ${WSO2_SERVER_HOME}/bin/editor.sh "$@"

--- a/dockerfiles/centos/manager/init.sh
+++ b/dockerfiles/centos/manager/init.sh
@@ -69,4 +69,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/manager.sh $*
+sh ${WSO2_SERVER_HOME}/bin/manager.sh "$@"

--- a/dockerfiles/centos/worker/init.sh
+++ b/dockerfiles/centos/worker/init.sh
@@ -69,4 +69,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/worker.sh $*
+sh ${WSO2_SERVER_HOME}/bin/worker.sh "$@"

--- a/dockerfiles/ubuntu/README.md
+++ b/dockerfiles/ubuntu/README.md
@@ -26,11 +26,11 @@ git clone https://github.com/wso2/docker-sp.git
 
 - Download [WSO2 Stream Processor 4.3.0 distribution](https://github.com/wso2/product-sp/releases) 
 and extract it to `<DOCKERFILE_HOME>/base/files`. <br>
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) and copy that to `<DOCKERFILE_HOME>/base/files` folder.<br>
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j) and copy that to `<DOCKERFILE_HOME>/base/files` folder.<br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
+  <DOCKERFILE_HOME>/base/files/mysql-connector-java-<version>-bin.jar
   <DOCKERFILE_HOME>/base/files/wso2sp-4.3.0/
   ```
   

--- a/dockerfiles/ubuntu/README.md
+++ b/dockerfiles/ubuntu/README.md
@@ -22,7 +22,7 @@ git clone https://github.com/wso2/docker-sp.git
 
 >The local copy of the `dockerfiles/ubuntu` directory will be referred to as `DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Copy and extract the JDK and WSO2 Stream Processor distributions to `<DOCKERFILE_HOME>/base/files`.
+##### 2. Copy and extract the WSO2 Stream Processor distribution to `<DOCKERFILE_HOME>/base/files`.
 
 - Download [WSO2 Stream Processor 4.3.0 distribution](https://github.com/wso2/product-sp/releases) 
 and extract it to `<DOCKERFILE_HOME>/base/files`. <br>

--- a/dockerfiles/ubuntu/README.md
+++ b/dockerfiles/ubuntu/README.md
@@ -22,17 +22,14 @@ git clone https://github.com/wso2/docker-sp.git
 
 >The local copy of the `dockerfiles/ubuntu` directory will be referred to as `DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Copy the extract JDK and WSO2 Stream Processor distributions to `<DOCKERFILE_HOME>/base/files`.
+##### 2. Copy and extract the JDK and WSO2 Stream Processor distributions to `<DOCKERFILE_HOME>/base/files`.
 
-- Download [JDK v1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) 
-and extract it to `<DOCKERFILE_HOME>/base/files`.
 - Download [WSO2 Stream Processor 4.3.0 distribution](https://github.com/wso2/product-sp/releases) 
 and extract it to `<DOCKERFILE_HOME>/base/files`. <br>
 - Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) and copy that to `<DOCKERFILE_HOME>/base/files` folder.<br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <DOCKERFILE_HOME>/base/files/jdk<version>/
   <DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
   <DOCKERFILE_HOME>/base/files/wso2sp-4.3.0/
   ```

--- a/dockerfiles/ubuntu/base/Dockerfile
+++ b/dockerfiles/ubuntu/base/Dockerfile
@@ -16,8 +16,8 @@
 #
 # ------------------------------------------------------------------------
 
-# set to latest Ubuntu LTS
-FROM ubuntu:18.04
+# set base Docker image to AdoptOpenJDK Ubuntu Docker image
+FROM adoptopenjdk/openjdk8:jdk8u192-b12
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations
@@ -28,9 +28,6 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
-# set jdk configurations
-ARG JDK=jdk1.8.0*
-ARG JAVA_HOME=${USER_HOME}/java
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2sp
 ARG WSO2_SERVER_VERSION=4.3.0
@@ -58,11 +55,9 @@ RUN apt-get update && \
 RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
     useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
 
-# copy the jdk and wso2 product distributions to user's home directory
-COPY --chown=wso2carbon:wso2 ${FILES}/${JDK} ${USER_HOME}/java/
+# copy the wso2 product distribution to user's home directory
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
-
-# copy the jdk and wso2 product distribution zip files to user's home directory
+# copy the Kafka client jars to the product home
 COPY --chown=wso2carbon:wso2 ${FILES}/kafka_2.11_0.10.0.0_1.0.0.jar ${WSO2_SERVER_HOME}/lib/
 COPY --chown=wso2carbon:wso2 ${FILES}/kafka_clients_0.10.0.0_1.0.0.jar ${WSO2_SERVER_HOME}/lib/
 COPY --chown=wso2carbon:wso2 ${FILES}/metrics_core_2.2.0_1.0.0.jar ${WSO2_SERVER_HOME}/lib/
@@ -78,7 +73,5 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV JAVA_HOME=${JAVA_HOME} \
-    PATH=$JAVA_HOME/bin:$PATH \
-    WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
+ENV WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
     WORKING_DIRECTORY=${USER_HOME}

--- a/dockerfiles/ubuntu/base/Dockerfile
+++ b/dockerfiles/ubuntu/base/Dockerfile
@@ -43,9 +43,7 @@ Read more about Apache License, Version 2.0 here @ http://www.apache.org/license
 
 # install required packages
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    curl \
-    netcat && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends netcat && \
     rm -rf /var/lib/apt/lists/* && \
     echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
     >> /etc/bash.bashrc \

--- a/dockerfiles/ubuntu/dashboard/init.sh
+++ b/dockerfiles/ubuntu/dashboard/init.sh
@@ -36,4 +36,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/dashboard.sh $*
+sh ${WSO2_SERVER_HOME}/bin/dashboard.sh "$@"

--- a/dockerfiles/ubuntu/editor/init.sh
+++ b/dockerfiles/ubuntu/editor/init.sh
@@ -36,4 +36,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/editor.sh $*
+sh ${WSO2_SERVER_HOME}/bin/editor.sh "$@"

--- a/dockerfiles/ubuntu/manager/init.sh
+++ b/dockerfiles/ubuntu/manager/init.sh
@@ -36,4 +36,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/manager.sh $*
+sh ${WSO2_SERVER_HOME}/bin/manager.sh "$@"

--- a/dockerfiles/ubuntu/worker/init.sh
+++ b/dockerfiles/ubuntu/worker/init.sh
@@ -36,4 +36,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start the WSO2 Carbon server profile
-sh ${WSO2_SERVER_HOME}/bin/worker.sh $*
+sh ${WSO2_SERVER_HOME}/bin/worker.sh "$@"


### PR DESCRIPTION
## Purpose
> It is suggested to use AdoptOpenJDK in Docker images for WSO2 Stream Processor profiles. This PR fixes https://github.com/wso2/docker-sp/issues/65, fixes https://github.com/wso2/docker-sp/issues/66 and fixes https://github.com/wso2/docker-sp/issues/70.

## Goals
> Use AdoptOpenJDK in Alpine, CentOS and Ubuntu based Docker images.