### PR TITLE
Add a volume mount to manager's deployment directory

### DIFF
--- a/docker-compose/sp-distributed/README.md
+++ b/docker-compose/sp-distributed/README.md
@@ -36,7 +36,8 @@
      ```
   4. Siddhi applications should be deployed to the manager cluster using following method.
   
-  Sending a "POST" request to http://<host>:<port>/siddhi-apps, with the Siddhi App attached as a file in the request as shown in the example below. 
+  - Copy the distributed siddhi app to **_sp-distributed/manager/siddhi-files_** directory.
+- Sending a "POST" request to http://<host>:<port>/siddhi-apps, with the Siddhi App attached as a file in the request as shown in the example below. 
   Refer [Stream Processor REST API Guide](https://docs.wso2.com/display/SP420/Stream+Processor+REST+API+Guide) for more information on using WSO2 Strean Processor APIs.
   
   Manager nodes are deployed under,
@@ -44,6 +45,4 @@
        Manager 1 - https://localhost:9543/
        Manager 2 - https://localhost:9544/
        ```
- > Refer [Stream Processor Fully Distributed Deployment](https://docs.wso2.com/display/SP420/Fully+Distributed+Deployment)   
-     
-
+> Refer [Stream Processor Fully Distributed Deployment Documentation](https://docs.wso2.com/display/SP4xx/Fully+Distributed+Deployment)

--- a/docker-compose/sp-distributed/docker-compose.yml
+++ b/docker-compose/sp-distributed/docker-compose.yml
@@ -62,7 +62,8 @@ services:
       timeout: 120s
       retries: 5
     volumes:
-      - ./manager:/home/wso2carbon/wso2-config-volume
+      - "./manager/conf:/home/wso2carbon/wso2-config-volume/conf"
+      - "./manager/siddhi-files:/home/wso2carbon/wso2sp-4.3.0/wso2/manager/deployment/siddhi-files"
     depends_on:
       mysql:
         condition: service_healthy
@@ -80,7 +81,8 @@ services:
       timeout: 120s
       retries: 5
     volumes:
-      - ./manager:/home/wso2carbon/wso2-config-volume
+      - "./manager/conf:/home/wso2carbon/wso2-config-volume/conf"
+      - "./manager/siddhi-files:/home/wso2carbon/wso2sp-4.3.0/wso2/manager/deployment/siddhi-files"
     depends_on:
       manager1:
         condition: service_healthy
@@ -122,40 +124,4 @@ services:
         condition: service_healthy
     environment:
       NODE_ID: wso2sp-worker-2
-      NODE_IP: 0.0.0.0
-  worker3:
-    image: docker.wso2.com/wso2sp-worker:4.3.0
-    container_name: wso2sp-worker-3
-    ports:
-      - "9003:9443"
-    healthcheck:
-      test: ["CMD", "nc", "-z","localhost", "9443"]
-      interval: 10s
-      timeout: 120s
-      retries: 5
-    volumes:
-       - ./worker:/home/wso2carbon/wso2-config-volume
-    depends_on:
-      manager1:
-        condition: service_healthy
-    environment:
-      NODE_ID: wso2sp-worker-3
-      NODE_IP: 0.0.0.0
-  worker4:
-    image: docker.wso2.com/wso2sp-worker:4.3.0
-    container_name: wso2sp-worker-4
-    ports:
-      - "9004:9443"
-    healthcheck:
-      test: ["CMD", "nc", "-z","localhost", "9443"]
-      interval: 10s
-      timeout: 120s
-      retries: 5
-    volumes:
-       - ./worker:/home/wso2carbon/wso2-config-volume
-    depends_on:
-      manager1:
-        condition: service_healthy
-    environment:
-      NODE_ID: wso2sp-worker-4
       NODE_IP: 0.0.0.0


### PR DESCRIPTION
## Purpose
> Fixes #76

## Goals
> Sync deployment content among clustered managers

## Approach
> Add a volume mount to manager's deployment directory

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? Not Applicable
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> docker-compose v1.18.0